### PR TITLE
feat(consent): integrate c15t v2 cookie consent with custom styling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,25 @@ CMS_API_TOKEN=your_strapi_api_token
 ALTCHA_HMAC_SECRET=your_altcha_hmac_secret
 
 ##################################
+# ******* Consent / c15t ******** #
+##################################
+
+# Operating mode for the c15t consent manager.
+# - "offline" (default) stores consent locally only and uses bundled offline policies
+# - "hosted"  persists consent records to a hosted c15t backend (consent.io)
+# - "c15t"    alias of "hosted" for legacy installations
+NEXT_PUBLIC_C15T_MODE=offline
+
+# Only relevant in "hosted" mode. URL of your c15t backend (e.g. via a Next.js
+# rewrite like `/api/c15t` or a direct consent.io endpoint).
+NEXT_PUBLIC_C15T_BACKEND_URL=/api/c15t
+
+# Google Analytics 4 / gtag.js measurement ID (starts with G-, AW- or DC-).
+# When unset, the gtag script is not loaded at all. When set, it is loaded
+# only after the user consents to the `measurement` category.
+NEXT_PUBLIC_GA_ID=
+
+##################################
 # ** Strapi CMS .env (reference) #
 ##################################
 # These variables belong in the Strapi project .env, NOT here.

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,8 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^~/(.*)$': '<rootDir>/public/$1',
     '^.+\\.(svg)$': '<rootDir>/src/__mocks__/svg.tsx',
+    '^@c15t/nextjs$': '<rootDir>/src/__mocks__/c15t-nextjs.tsx',
+    '^@c15t/scripts/.*$': '<rootDir>/src/__mocks__/c15t-scripts.ts',
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     ]
   },
   "dependencies": {
+    "@c15t/nextjs": "2.0.0",
+    "@c15t/scripts": "2.0.0",
     "@hookform/resolvers": "5.2.2",
     "@react-email/components": "1.0.12",
     "@strapi/blocks-react-renderer": "1.0.2",
@@ -90,6 +92,7 @@
     "jest-environment-jsdom": "30.3.0",
     "lint-staged": "16.4.0",
     "postcss": "8.5.10",
+    "postcss-import": "16.1.1",
     "prettier": "3.8.3",
     "prettier-plugin-tailwindcss": "0.7.2",
     "tailwindcss": "3.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
 
   .:
     dependencies:
+      '@c15t/nextjs':
+        specifier: 2.0.0
+        version: 2.0.0(@types/react@19.2.14)(next@16.2.4(@babel/core@7.27.4)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@c15t/scripts':
+        specifier: 2.0.0
+        version: 2.0.0
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
@@ -148,6 +154,9 @@ importers:
       postcss:
         specifier: 8.5.10
         version: 8.5.10
+      postcss-import:
+        specifier: 16.1.1
+        version: 16.1.1(postcss@8.5.10)
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -344,6 +353,31 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@c15t/nextjs@2.0.0':
+    resolution: {integrity: sha512-WIhf9tDdmTqCmNFtHALo/dn6c2rbWANlROjnKeET45gcuACJOeaCpJhs9f0zv2meX6LV8N+85qcgVB/HW5SCGQ==}
+    peerDependencies:
+      next: ^16.0.0 || ^15.0.0 || ^14.0.0 || ^13.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  '@c15t/react@2.0.0':
+    resolution: {integrity: sha512-MCWp8mhAyjJJo64x5E37sQLe6n3eZEhwCNnSunAL8IJuB3lQeLIbE62NFiLZfIS21NpLJaSUg+fkCwL5P70WWw==}
+    peerDependencies:
+      react: ^19.0.0 || ^19.0.0-rc || ^18.0.0 || ^17.0.0 || ^16.8.0
+      react-dom: ^19.0.0 || ^19.0.0-rc || ^18.0.0 || ^17.0.0 || ^16.8.0
+
+  '@c15t/schema@2.0.0':
+    resolution: {integrity: sha512-NmNH+pkK/yq7Sknrpdi4zGAjDkwd/bu4q3rtzjlJdl0zdxUfNhJnlOOwQ6gHSwchYI4jiphL0IsEBEYVwqjLxw==}
+
+  '@c15t/scripts@2.0.0':
+    resolution: {integrity: sha512-b5GJaqSh22gRxAswl4kv2DGXocKqvayAPZ5L2OWSRc+d/H1Q1EdB4+xyDZ/bL33rB+CetUc3UNVbIUlw+jdLcg==}
+
+  '@c15t/translations@2.0.0':
+    resolution: {integrity: sha512-FLMx8QEvZdkBGdFk+yiPuLUry4NVZjarNbBjISnNQsPzfmtjWOmtY/k5+J1jxGCyWPP8GN7KtqxJw+lU5vcOjw==}
+
+  '@c15t/ui@2.0.0':
+    resolution: {integrity: sha512-4Ym5QL9aa4ccfQv7f2qpVO6AwXTtnNCQkqqxTFxLpSPKEvPFFpWDkVXCBYz75qApn2Y0mvIjdw/VJQmj4OsPaQ==}
 
   '@commitlint/cli@20.5.0':
     resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
@@ -1618,6 +1652,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  c15t@2.0.0:
+    resolution: {integrity: sha512-ApF6BO7BQ5nsn2pq43Rjg///iph5hv2fVPcAjSJYhLC18bMYigs8Pg++jTfP4vZmmqK68zexFGO5ScgeoLxxhg==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2536,10 +2573,6 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.15.1:
-    resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
-    engines: {node: '>= 0.4'}
-
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -3327,6 +3360,12 @@ packages:
     peerDependencies:
       postcss: ^8.0.0
 
+  postcss-import@16.1.1:
+    resolution: {integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
   postcss-js@4.0.1:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -3968,6 +4007,14 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -4098,6 +4145,24 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': 19.2.14
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -4308,6 +4373,53 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@c15t/nextjs@2.0.0(@types/react@19.2.14)(next@16.2.4(@babel/core@7.27.4)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+    dependencies:
+      '@c15t/react': 2.0.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      '@c15t/translations': 2.0.0
+      c15t: 2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)
+      next: 16.2.4(@babel/core@7.27.4)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - typescript
+      - use-sync-external-store
+
+  '@c15t/react@2.0.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)':
+    dependencies:
+      '@c15t/ui': 2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)
+      c15t: 2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - typescript
+      - use-sync-external-store
+
+  '@c15t/schema@2.0.0(typescript@5.9.3)':
+    dependencies:
+      valibot: 1.3.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@c15t/scripts@2.0.0': {}
+
+  '@c15t/translations@2.0.0': {}
+
+  '@c15t/ui@2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)':
+    dependencies:
+      '@c15t/translations': 2.0.0
+      c15t: 2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
 
   '@commitlint/cli@20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
     dependencies:
@@ -5651,6 +5763,18 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  c15t@2.0.0(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3):
+    dependencies:
+      '@c15t/schema': 2.0.0(typescript@5.9.3)
+      '@c15t/translations': 2.0.0
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6761,10 +6885,6 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.15.1:
-    dependencies:
-      hasown: 2.0.2
-
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -7749,6 +7869,13 @@ snapshots:
       read-cache: 1.0.0
       resolve: 1.22.8
 
+  postcss-import@16.1.1(postcss@8.5.10):
+    dependencies:
+      postcss: 8.5.10
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+
   postcss-js@4.0.1(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
@@ -7918,7 +8045,7 @@ snapshots:
 
   resolve@1.22.8:
     dependencies:
-      is-core-module: 2.15.1
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -8485,6 +8612,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  valibot@1.3.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -8640,3 +8771,8 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    'postcss-import': {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/src/__mocks__/c15t-nextjs.tsx
+++ b/src/__mocks__/c15t-nextjs.tsx
@@ -1,0 +1,27 @@
+/**
+ * Jest mock for `@c15t/nextjs`.
+ *
+ * The real package pulls in Next.js server-only modules (via
+ * `next/cache`) which are not available inside `jest-environment-jsdom`.
+ * This mock provides the minimal surface used by our own components.
+ */
+import type { ReactNode } from 'react';
+
+export const ConsentManagerProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => <>{children}</>;
+
+export const ConsentBanner = () => null;
+export const ConsentDialog = () => null;
+export const ConsentWidget = () => null;
+
+export const useConsentManager = () => ({
+  setActiveUI: () => undefined,
+  saveConsents: () => undefined,
+  resetConsents: () => undefined,
+  gdprConsents: {},
+});
+
+export type Theme = Record<string, unknown>;

--- a/src/__mocks__/c15t-scripts.ts
+++ b/src/__mocks__/c15t-scripts.ts
@@ -1,0 +1,25 @@
+/**
+ * Jest mock for `@c15t/scripts/*` helper packages (e.g. `google-tag`).
+ *
+ * Returns a plain `Script`-shaped object so that any consumer calling
+ * `gtag(...)` or similar factory keeps working in the test environment.
+ */
+export const gtag = (options: { id: string; category: string }) => ({
+  id: `gtag-${options.id}`,
+  category: options.category,
+  src: `https://www.googletagmanager.com/gtag/js?id=${options.id}`,
+});
+
+const scriptFactory = (name: string) => () => ({
+  id: name,
+  category: 'measurement',
+});
+
+export const metaPixel = scriptFactory('meta-pixel');
+export const googleTagManager = scriptFactory('google-tag-manager');
+export const linkedinInsights = scriptFactory('linkedin-insights');
+export const microsoftUet = scriptFactory('microsoft-uet');
+export const tiktokPixel = scriptFactory('tiktok-pixel');
+export const xPixel = scriptFactory('x-pixel');
+export const posthog = scriptFactory('posthog');
+export const databuddy = scriptFactory('databuddy');

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from 'next';
+
+import CookiePolicy from '@/components/templates/CookiePolicy';
+
+export const metadata: Metadata = {
+  title: 'Cookie Policy, Project Sentiment (dot) org',
+  description:
+    'Cookie policy and transparent consent control center for the SENTIMENT research project. Part of the German government\'s research framework program on IT security "Digital. Secure. Sovereign".',
+};
+
+export default function CookiesPage() {
+  return <CookiePolicy />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import '../styles/globals.css';
 
 import { CircularStd } from '@/lib/fonts';
 
+import { ConsentManager } from '@/components/helpers/ConsentManager';
 import { ThemeProvider } from '@/components/helpers/ThemeProvider';
 import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
@@ -19,17 +20,19 @@ export default function RootLayout({
     <html lang='en' className={CircularStd.className} suppressHydrationWarning>
       <body suppressHydrationWarning={true}>
         <ThemeProvider>
-          <a
-            href='#main-content'
-            className='sr-only z-50 rounded-md bg-primary px-4 py-2 text-black focus:not-sr-only focus:absolute focus:left-4 focus:top-4'
-          >
-            Skip to main content
-          </a>
-          <Header />
-          <main id='main-content'>{children}</main>
-          <NewsletterCTA />
-          <Footer />
-          <VisualGrid />
+          <ConsentManager>
+            <a
+              href='#main-content'
+              className='sr-only z-50 rounded-md bg-primary px-4 py-2 text-black focus:not-sr-only focus:absolute focus:left-4 focus:top-4'
+            >
+              Skip to main content
+            </a>
+            <Header />
+            <main id='main-content'>{children}</main>
+            <NewsletterCTA />
+            <Footer />
+            <VisualGrid />
+          </ConsentManager>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/helpers/ConsentManager.tsx
+++ b/src/components/helpers/ConsentManager.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import {
+  ConsentBanner,
+  ConsentDialog,
+  ConsentManagerProvider,
+  type Theme,
+} from '@c15t/nextjs';
+import { gtag } from '@c15t/scripts/google-tag';
+import type { ComponentProps, ReactNode } from 'react';
+
+import {
+  consentBackendURL,
+  consentMode,
+  googleAnalyticsId,
+} from '@/constant/consent';
+
+type ConsentManagerOptions = ComponentProps<
+  typeof ConsentManagerProvider
+>['options'];
+
+/**
+ * Theme tokens tuned to match the SENTIMENT design system.
+ *
+ * We only use design tokens / slots (no global CSS overrides) so the c15t
+ * components can be rendered inside a portal without inheriting any unrelated
+ * styles from the parent tree. The values mirror the palette defined in
+ * `tailwind.config.ts` and `globals.css`.
+ */
+const consentTheme = {
+  colors: {
+    primary: '#FF5C24',
+    primaryHover: '#1F35A5',
+    surface: '#ffffff',
+    surfaceHover: '#f2f2f2',
+    text: '#121212',
+    textMuted: '#8b9094',
+    border: '#121212',
+  },
+  dark: {
+    primary: '#FF5C24',
+    primaryHover: '#FF5C24',
+    surface: '#121212',
+    surfaceHover: '#222222',
+    text: '#f5f5f5',
+    textMuted: '#9ca3af',
+    border: 'rgba(255,255,255,0.2)',
+  },
+  typography: {
+    fontFamily:
+      'CircularStd, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+  },
+  radius: {
+    sm: '0.5rem',
+    md: '0.75rem',
+    lg: '1rem',
+    full: '9999px',
+  },
+  shadows: {
+    md: '0 10px 30px -10px rgba(0, 0, 0, 0.15)',
+  },
+  consentActions: {
+    default: { mode: 'stroke' as const },
+    accept: { variant: 'primary' as const, mode: 'filled' as const },
+    customize: { variant: 'neutral' as const, mode: 'ghost' as const },
+    reject: { variant: 'neutral' as const, mode: 'stroke' as const },
+  },
+  slots: {
+    consentBannerCard:
+      'rounded-2xl border border-solid border-black/10 bg-white/95 shadow-lg backdrop-blur-md dark:border-white/10 dark:bg-neutral-950/95',
+    consentBannerHeader: 'gap-2',
+    consentBannerTitle: 'font-primary tracking-tighter',
+    consentBannerDescription: 'text-tertiary',
+    consentBannerFooter: 'border-t border-grid px-6 py-4',
+    consentDialogCard:
+      'rounded-2xl border border-solid border-black/10 bg-white shadow-xl dark:border-white/10 dark:bg-neutral-950',
+    consentDialogHeader: 'gap-2',
+    consentDialogTag: 'shadow-none',
+    consentWidgetAccordion:
+      'rounded-xl border border-solid border-grid bg-white dark:bg-neutral-950',
+    consentWidgetFooter: 'border-t border-grid pt-4',
+    toggle: 'shadow-sm',
+  },
+} satisfies Theme;
+
+/**
+ * Internationalisation config; keeps copy in line with the rest of the
+ * SENTIMENT site (EN default, DE available because the site is bilingual).
+ */
+const i18n = {
+  locale: 'en',
+  detectBrowserLanguage: true,
+  messages: {
+    en: {
+      cookieBanner: {
+        title: 'We value your privacy',
+        description:
+          'We use cookies to run essential parts of this site and — only with your permission — to measure how our research content is received. You can change your choice any time via the cookie settings in the footer or on the privacy page.',
+      },
+      consentManagerDialog: {
+        title: 'Cookie settings',
+        description:
+          'Choose which types of cookies you allow. Necessary cookies are required for the site to work and are always active.',
+      },
+      common: {
+        acceptAll: 'Accept all',
+        rejectAll: 'Reject all',
+        customize: 'Customize',
+        save: 'Save preferences',
+      },
+    },
+    de: {
+      cookieBanner: {
+        title: 'Ihre Privatsphäre ist uns wichtig',
+        description:
+          'Wir verwenden Cookies, um die grundlegenden Funktionen dieser Seite bereitzustellen und — nur mit Ihrer Zustimmung — um zu messen, wie unsere Forschungsinhalte genutzt werden. Sie können Ihre Auswahl jederzeit über die Cookie-Einstellungen im Footer oder auf der Datenschutz-Seite ändern.',
+      },
+      consentManagerDialog: {
+        title: 'Cookie-Einstellungen',
+        description:
+          'Wählen Sie aus, welche Cookie-Arten Sie zulassen möchten. Technisch notwendige Cookies sind für den Betrieb der Website erforderlich und immer aktiv.',
+      },
+      common: {
+        acceptAll: 'Alle akzeptieren',
+        rejectAll: 'Alle ablehnen',
+        customize: 'Anpassen',
+        save: 'Auswahl speichern',
+      },
+    },
+  },
+};
+
+/**
+ * Shared options that are independent of the selected client mode.
+ */
+const sharedOptions = {
+  consentCategories: ['necessary', 'measurement', 'marketing'],
+  theme: consentTheme,
+  colorScheme: 'system',
+  scrollLock: false,
+  trapFocus: true,
+  legalLinks: {
+    privacyPolicy: { href: '/privacy', target: '_self' },
+    cookiePolicy: { href: '/cookies', target: '_self' },
+    termsOfService: { href: '/legal-notice', target: '_self' },
+  },
+  i18n,
+} as const satisfies Partial<ConsentManagerOptions>;
+
+function buildOptions(
+  scripts: ConsentManagerOptions['scripts'],
+): ConsentManagerOptions {
+  if (consentMode === 'hosted' || consentMode === 'c15t') {
+    return {
+      ...sharedOptions,
+      mode: consentMode,
+      backendURL: consentBackendURL,
+      scripts,
+    } as ConsentManagerOptions;
+  }
+
+  return {
+    ...sharedOptions,
+    mode: 'offline',
+    scripts,
+  } as ConsentManagerOptions;
+}
+
+export function ConsentManager({ children }: { children: ReactNode }) {
+  // Only load the GA/gtag integration when a measurement ID is configured.
+  // The integration automatically sets Google Consent Mode v2 defaults to
+  // "denied" and flips the relevant signals once a user accepts measurement.
+  const scripts = googleAnalyticsId
+    ? [
+        gtag({
+          id: googleAnalyticsId,
+          category: 'measurement',
+        }),
+      ]
+    : undefined;
+
+  return (
+    <ConsentManagerProvider options={buildOptions(scripts)}>
+      <ConsentBanner />
+      <ConsentDialog />
+      {children}
+    </ConsentManagerProvider>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
 import { fetchAPI } from '@/lib/fetch-api';
 
 import { Container } from '@/components/layout/Container';
+import { CookieSettingsButton } from '@/components/ui/CookieSettingsButton';
 import { Logo } from '@/components/ui/icons/Logo';
 import { Link } from '@/components/ui/Link';
 
@@ -130,6 +131,14 @@ export default async function Footer() {
                 </li>
                 <li>
                   <Link
+                    href='/cookies'
+                    className='text-tertiary transition-colors hover:text-primary hover:underline'
+                  >
+                    Cookie Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
                     href='/contact'
                     className='text-tertiary transition-colors hover:text-primary hover:underline'
                   >
@@ -141,11 +150,12 @@ export default async function Footer() {
           </div>
 
           {/* Bottom Bar */}
-          <div className='mt-12 border-t border-grid pt-8 text-center text-sm text-tertiary'>
+          <div className='mt-12 flex flex-col items-center justify-between gap-4 border-t border-grid pt-8 text-center text-sm text-tertiary sm:flex-row sm:text-left'>
             <p>
               © {new Date().getFullYear()} SENTIMENT Project. All rights
               reserved.
             </p>
+            <CookieSettingsButton>Cookie settings</CookieSettingsButton>
           </div>
         </div>
       </Container>

--- a/src/components/templates/CookieControlCenter.tsx
+++ b/src/components/templates/CookieControlCenter.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { ConsentWidget, useConsentManager } from '@c15t/nextjs';
+
+import clsxm from '@/lib/clsxm';
+
+import { Button } from '@/components/ui/Button';
+import { Paragraph, Title } from '@/components/ui/typography';
+
+/**
+ * Inline consent control center — mirrors the visual language of the
+ * newsletter CTA (`NewsletterCTA`) with a two-column rounded card.
+ *
+ * The left column explains the control, the right column embeds the c15t
+ * `ConsentWidget` so users can toggle categories right inside the privacy
+ * policy page, without opening any modal.
+ */
+export function CookieControlCenter({ className }: { className?: string }) {
+  const { saveConsents, resetConsents } = useConsentManager();
+
+  return (
+    <div
+      id='cookie-settings'
+      className={clsxm('scroll-mt-24 px-2 sm:px-4', className)}
+    >
+      <div className='group grid grid-cols-1 gap-8 rounded-lg bg-primary/5 p-8 hover:bg-primary/20 lg:grid-cols-2 lg:gap-12 lg:p-12'>
+        {/* Text Section - Left */}
+        <div className='flex flex-col justify-center'>
+          <Title
+            renderAs='h2'
+            size='three'
+            className='mb-4 group-hover:underline group-hover:decoration-primary/50'
+          >
+            Cookie <br />
+            Control Center
+          </Title>
+          <Paragraph className='mb-6 text-base' color='light'>
+            Fine-tune which categories of cookies we may use while you browse
+            our research content. Changes are applied immediately and stored in
+            a consent record on your device.
+          </Paragraph>
+          <div className='space-y-2 text-sm text-tertiary'>
+            <p className='flex items-center gap-2'>
+              <span className='text-primary'>✓</span>
+              Toggle categories individually
+            </p>
+            <p className='flex items-center gap-2'>
+              <span className='text-primary'>✓</span>
+              Scripts load only after your consent
+            </p>
+            <p className='flex items-center gap-2'>
+              <span className='text-primary'>✓</span>
+              Revoke or reset any time
+            </p>
+          </div>
+          <div className='mt-6 flex flex-wrap items-center gap-3'>
+            <Button type='button' onClick={() => saveConsents('all')}>
+              Accept all
+            </Button>
+            <button
+              type='button'
+              onClick={() => saveConsents('necessary')}
+              className='rounded-full border border-solid border-text/30 px-4 py-1 text-sm text-text transition-colors hover:border-primary hover:bg-primary/10 hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg dark:border-white/30'
+            >
+              Reject non-essential
+            </button>
+            <button
+              type='button'
+              onClick={() => resetConsents()}
+              className='text-sm text-tertiary underline underline-offset-4 transition-colors hover:text-primary'
+            >
+              Reset my choice
+            </button>
+          </div>
+        </div>
+
+        {/* Widget Section - Right */}
+        <div className='flex flex-col justify-center'>
+          <div className='rounded-lg border border-solid border-grid bg-bg p-4 sm:p-6'>
+            <ConsentWidget
+              hideBranding
+              legalLinks={['privacyPolicy', 'cookiePolicy']}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/templates/CookiePolicy.tsx
+++ b/src/components/templates/CookiePolicy.tsx
@@ -1,0 +1,141 @@
+import { Container } from '@/components/layout/Container';
+import { CookieControlCenter } from '@/components/templates/CookieControlCenter';
+import Crossbar from '@/components/templates/Crossbar';
+import { Link } from '@/components/ui/Link';
+import { List, ListItem } from '@/components/ui/List';
+import { Paragraph, Title } from '@/components/ui/typography';
+
+function CookieHero() {
+  return (
+    <div className='border-b-solid mb-12 border-b-[1px] border-b-grid pb-12 sm:mb-24 sm:pb-24'>
+      <div className='grid grid-cols-3 gap-0 sm:grid-cols-4'>
+        <div className='z-20 col-span-3 sm:col-span-4'>
+          <Title className='leading-none' size='two'>
+            Cookie{' '}
+            <span className='font-secondary italic text-primary'>Policy</span> &{' '}
+            <span className='font-secondary italic text-primary'>
+              Transparency
+            </span>{' '}
+            — what we store, for how long, and why
+          </Title>
+        </div>
+        <div className='z-10 col-span-3 mt-8 sm:col-span-4'>
+          <Paragraph>
+            Because our research engages with sensitive questions of privacy and
+            intimacy, we treat cookies the same way: with care, clear purpose,
+            and explicit consent. This page explains which cookies and browser
+            storage items we use, what happens when you accept or reject them,
+            and how you can change your choice later.
+          </Paragraph>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function CookiePolicy() {
+  return (
+    <section className='py-24 sm:py-36'>
+      <Container>
+        <Crossbar />
+        <div className='px-2 sm:px-4'>
+          <CookieHero />
+
+          <Title size='five' className='mt-12'>
+            1. What are cookies?
+          </Title>
+          <Paragraph>
+            Cookies are small text files that websites place on your device to
+            remember information between visits. Similar mechanisms — such as
+            <em> localStorage</em>, <em>sessionStorage</em>, or fingerprinting
+            pixels — can have the same effect. Where this policy refers to
+            &quot;cookies&quot; it covers all of these equivalent technologies.
+          </Paragraph>
+
+          <Title size='five' className='mt-12'>
+            2. Legal basis and approach
+          </Title>
+          <Paragraph>
+            For strictly necessary cookies we rely on our legitimate interest in
+            operating this website (Art. 6 (1) lit. f GDPR, § 25 (2) No. 2
+            TTDSG). All other cookies are only set after you have actively
+            consented via our cookie dialog (Art. 6 (1) lit. a GDPR, § 25 (1)
+            TTDSG). You can withdraw your consent at any time with effect for
+            the future.
+          </Paragraph>
+
+          <Title size='five' className='mt-12'>
+            3. Categories we distinguish
+          </Title>
+          <Paragraph>
+            Our consent manager groups cookies into the following categories.
+            You can toggle each category individually in the{' '}
+            <Link href='#cookie-settings' variant='underline'>
+              Cookie Control Center
+            </Link>{' '}
+            below.
+          </Paragraph>
+          <List>
+            <ListItem>
+              <strong>Necessary</strong> — required for core functionality such
+              as route navigation, security protection (e.g. the ALTCHA bot
+              challenge), and remembering your consent preference. These cookies
+              cannot be disabled.
+            </ListItem>
+            <ListItem>
+              <strong>Measurement</strong> — anonymous analytics that help us
+              understand which research content is read and where users get
+              stuck. Only loaded after explicit consent; Google Consent Mode v2
+              defaults are set to &quot;denied&quot; until then.
+            </ListItem>
+            <ListItem>
+              <strong>Marketing</strong> — currently unused. Reserved for future
+              conversion or remarketing tags; will remain inactive unless and
+              until this policy is updated and you consent.
+            </ListItem>
+          </List>
+
+          <Title size='five' className='mt-12'>
+            4. Third-party services
+          </Title>
+          <Paragraph>
+            Third-party scripts (e.g. Google Analytics 4 via{' '}
+            <code>gtag.js</code>) are not loaded until you have granted consent
+            for the relevant category. We use the c15t script loader to block
+            and unblock these scripts in real time so that no tracking network
+            request is made while you have not yet consented.
+          </Paragraph>
+
+          <Title size='five' className='mt-12'>
+            5. Retention and deletion
+          </Title>
+          <Paragraph>
+            Your consent record is stored on your device for up to twelve
+            months, after which we will ask you again. Category-specific cookies
+            follow their own expiry (listed by the individual vendor). You can
+            reset everything using the &quot;Reset my choice&quot; link below,
+            or by deleting the cookies via your browser settings.
+          </Paragraph>
+
+          <Title size='five' className='mt-12'>
+            6. Your rights
+          </Title>
+          <Paragraph>
+            Under the GDPR you have the right to access, rectify, and erase your
+            personal data, to restrict or object to processing, and to data
+            portability. A full overview is available in our{' '}
+            <Link href='/privacy' variant='underline'>
+              privacy policy
+            </Link>
+            . To withdraw consent that was previously granted through the cookie
+            dialog, use the Cookie Control Center below — no email is required.
+          </Paragraph>
+        </div>
+
+        <div className='mt-16 sm:mt-24'>
+          <CookieControlCenter />
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/components/templates/Privacy.tsx
+++ b/src/components/templates/Privacy.tsx
@@ -1,4 +1,5 @@
 import { Container } from '@/components/layout/Container';
+import { CookieControlCenter } from '@/components/templates/CookieControlCenter';
 import Crossbar from '@/components/templates/Crossbar';
 import { Link } from '@/components/ui/Link';
 import { List, ListItem } from '@/components/ui/List';
@@ -69,22 +70,43 @@ export default function Privacy() {
           </Paragraph>
 
           <Title size='five' className='mt-12'>
-            3. Cookies
+            3. Cookies und vergleichbare Technologien
           </Title>
           <Paragraph>
-            Diese Website verwendet ausschließlich technisch notwendige Cookies.
-            Cookies sind kleine Textdateien, die auf Ihrem Endgerät gespeichert
-            werden und keine Schäden verursachen.
+            Diese Website verwendet technisch notwendige Cookies sowie – nur mit
+            Ihrer ausdrücklichen Einwilligung – optionale Cookies für
+            Reichweitenmessung. Details zu den einzelnen Kategorien, den
+            eingesetzten Diensten sowie zur Speicherdauer finden Sie in unserer{' '}
+            <Link href='/cookies' variant='underline'>
+              Cookie Policy
+            </Link>
+            .
           </Paragraph>
           <Paragraph>
-            Sie können die Speicherung von Cookies durch entsprechende
-            Einstellungen in Ihrem Browser verhindern. In diesem Fall kann es
-            jedoch zu Funktionseinschränkungen dieser Website kommen.
+            Ihre Einwilligung können Sie jederzeit im Cookie Control Center
+            weiter unten auf dieser Seite oder über den Link &quot;Cookie
+            settings&quot; im Footer erteilen, anpassen oder widerrufen. Bis zur
+            Erteilung einer Einwilligung werden optionale Skripte vollständig
+            blockiert (Skript-Blocker auf Basis von c15t & Google Consent Mode
+            v2).
           </Paragraph>
           <Paragraph>
-            Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse
-            an der technischen Funktionalität der Website)
+            Rechtsgrundlage: Art. 6 Abs. 1 lit. a DSGVO i. V. m. § 25 Abs. 1
+            TTDSG für optionale Cookies; Art. 6 Abs. 1 lit. f DSGVO i. V. m. §
+            25 Abs. 2 Nr. 2 TTDSG für technisch notwendige Cookies.
           </Paragraph>
+
+          <Title size='five' className='mt-12'>
+            3a. Cookie Control Center
+          </Title>
+          <Paragraph>
+            Im folgenden Control Center können Sie Ihre Einwilligung
+            feingranular steuern. Änderungen wirken sofort und werden als
+            Einwilligungsnachweis lokal auf Ihrem Endgerät gespeichert.
+          </Paragraph>
+          <div className='mt-8'>
+            <CookieControlCenter className='!px-0 sm:!px-0' />
+          </div>
 
           <Title size='five' className='mt-12'>
             4. Kontaktaufnahme per E-Mail

--- a/src/components/ui/CookieSettingsButton.tsx
+++ b/src/components/ui/CookieSettingsButton.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useConsentManager } from '@c15t/nextjs';
+import type { ReactNode } from 'react';
+
+import clsxm from '@/lib/clsxm';
+
+/**
+ * Small pill-style button that opens the c15t consent dialog.
+ *
+ * Used for the "manage cookies" affordance in the footer and anywhere else
+ * where a user should be able to re-open their consent preferences without
+ * navigating to the dedicated cookies page.
+ */
+export function CookieSettingsButton({
+  children = 'Cookie settings',
+  className,
+}: {
+  children?: ReactNode;
+  className?: string;
+}) {
+  const { setActiveUI } = useConsentManager();
+
+  return (
+    <button
+      type='button'
+      onClick={() => setActiveUI('dialog')}
+      className={clsxm(
+        'inline-flex items-center justify-center rounded-full border border-solid border-text/30 px-4 py-1 text-sm text-text transition-colors hover:border-primary hover:bg-primary/10 hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg',
+        'dark:border-white/30 dark:text-text dark:hover:border-primary',
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/constant/consent.ts
+++ b/src/constant/consent.ts
@@ -1,0 +1,19 @@
+/**
+ * Configuration for the c15t consent manager.
+ *
+ * Values are read from `NEXT_PUBLIC_*` environment variables so that they are
+ * available both during server rendering and on the client.
+ *
+ * Fill these in via `.env.local` (see `.env.example`).
+ */
+
+export const consentMode = (process.env.NEXT_PUBLIC_C15T_MODE ?? 'offline') as
+  | 'offline'
+  | 'hosted'
+  | 'c15t'
+  | 'custom';
+
+export const consentBackendURL =
+  process.env.NEXT_PUBLIC_C15T_BACKEND_URL ?? '/api/c15t';
+
+export const googleAnalyticsId = process.env.NEXT_PUBLIC_GA_ID ?? '';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,6 @@
 @tailwind base;
 @tailwind components;
+@import '@c15t/nextjs/styles.tw3.css';
 @tailwind utilities;
 
 :root {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a GDPR/TTDSG-compliant cookie consent layer on top of the existing SENTIMENT design system, powered by [`@c15t/nextjs` v2](https://www.npmjs.com/package/@c15t/nextjs). Styling is fully driven through c15t's theme tokens/slots so the banner, dialog and inline widget match the hero and newsletter section of the site (rounded cards on `primary/5`, hover on `primary/20`, `CircularStd` typography, light/dark palette from `tailwind.config.ts`).

## What the user gets

- **Cookie dialog (modal)** — `ConsentDialog` with category toggles, opened from the banner's "Customize" button or the footer's "Cookie settings" pill.
- **Cookie banner** — shows up in opt-in jurisdictions; three actions (accept / reject / customize) with styling driven by `theme.consentActions` (accept = filled primary, customize = ghost, reject = neutral stroke).
- **Inline Cookie Control Center** — embedded on the new `/cookies` page _and_ on the existing privacy page (`/privacy`). Mirrors the newsletter CTA (`NewsletterCTA`) two-column rounded card, wrapping `ConsentWidget` on the right with explicit "Accept all / Reject non-essential / Reset my choice" actions on the left.
- **Cookie policy page** (`/cookies`) — best-practice copy covering definition, legal basis (Art. 6 (1) lit. a/f GDPR, § 25 TTDSG), categories (necessary, measurement, marketing), third-party scripts, retention and user rights.
- **Script blocker** — optional scripts are only loaded after consent (`c15t` script loader). Example wired in: Google Analytics via `@c15t/scripts/google-tag` with automatic Google Consent Mode v2 defaults (`denied` until measurement is granted).
- **Privacy policy update** — section 3 rewritten to reference the cookie policy, explains that optional scripts are blocked until consent is granted, cites the correct TTDSG legal basis, and embeds the control center inline (section 3a).

## Implementation details

### New / touched files

- `src/components/helpers/ConsentManager.tsx` — provider with custom theme (tokens + slots), bilingual (`en`/`de`) copy via `options.i18n`, legal-link wiring, optional GA4 via `@c15t/scripts/google-tag`, and a `buildOptions()` helper that lets `NEXT_PUBLIC_C15T_MODE` toggle between `offline` (default, zero-config) and `hosted`.
- `src/components/templates/CookiePolicy.tsx` + `src/app/cookies/page.tsx` — dedicated `/cookies` route with the policy + inline control center.
- `src/components/templates/CookieControlCenter.tsx` — inline widget reusing the newsletter visual language.
- `src/components/ui/CookieSettingsButton.tsx` — small pill button that calls `setActiveUI('dialog')` to reopen preferences anywhere.
- `src/components/layout/Footer.tsx` — added a "Cookie settings" button and a "Cookie Policy" link.
- `src/components/templates/Privacy.tsx` — rewrote the cookies section, added section 3a with the inline control center.
- `src/constant/consent.ts` — reads `NEXT_PUBLIC_C15T_MODE`, `NEXT_PUBLIC_C15T_BACKEND_URL`, `NEXT_PUBLIC_GA_ID`.
- `src/styles/globals.css` + `postcss.config.js` — adds `@import "@c15t/nextjs/styles.tw3.css"` between `@tailwind components;` and `@tailwind utilities;` and installs `postcss-import` so the `@import` is inlined before the CSS nesting rules are generated.
- `src/app/layout.tsx` — wraps the tree with `<ConsentManager>` below the `ThemeProvider` so the c15t store can observe the dark-mode class set by `next-themes`.
- `.env.example` — documents the new env vars.
- `tsconfig.json` — `moduleResolution` bumped from `node` to `bundler` so the c15t subpath exports (`@c15t/scripts/google-tag`) resolve.
- `src/__mocks__/c15t-nextjs.tsx` + `src/__mocks__/c15t-scripts.ts` + `jest.config.js` — jest mocks so the jsdom test environment does not try to load `next/cache` through the real package.

### Design tokens

Custom `Theme` uses the SENTIMENT palette:

| Token | Light | Dark |
| --- | --- | --- |
| `primary` | `#FF5C24` | `#FF5C24` |
| `surface` | `#ffffff` | `#121212` |
| `surfaceHover` | `#f2f2f2` | `#222222` |
| `text` | `#121212` | `#f5f5f5` |
| `textMuted` | `#8b9094` | `#9ca3af` |

Slots override `consentBannerCard`, `consentBannerFooter`, `consentDialogCard`, `consentWidgetAccordion`, `consentWidgetFooter`, `toggle`, etc. to match the rounded/soft-shadow aesthetic.

### Consent categories

Three categories are exposed: `necessary`, `measurement`, `marketing`. Mapping to Google Consent Mode v2 happens automatically via `@c15t/scripts/google-tag`.

### Environment

```env
# Operating mode for c15t (offline = local-only, hosted = via consent.io or self-host)
NEXT_PUBLIC_C15T_MODE=offline
# Only used in hosted mode
NEXT_PUBLIC_C15T_BACKEND_URL=/api/c15t
# Optional — when set, GA4 loads only after the user consents to "measurement"
NEXT_PUBLIC_GA_ID=
```

## Verification

- `pnpm typecheck` — ✓
- `pnpm test` — ✓ (378 tests, 30 suites)
- `npx eslint src` — ✓
- `pnpm format:check` — ✓
- `pnpm build` fails only on the existing `/articles/[slug]` page because no Strapi CMS is reachable from the cloud VM; the CSS pipeline and all new routes compile cleanly.

## Next steps (optional, not in this PR)

- Switch `NEXT_PUBLIC_C15T_MODE=hosted` and point `NEXT_PUBLIC_C15T_BACKEND_URL` at a [consent.io](https://consent.io) instance (or self-hosted deployment) for durable consent records and jurisdiction auto-detection.
- Provide a `NEXT_PUBLIC_GA_ID` to activate GA4; no additional code change required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1df08cf5-5895-401c-b394-4e935fbb8095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1df08cf5-5895-401c-b394-4e935fbb8095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

