### PR TITLE
Expose Exhibition under /exhibition + mobile navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint src",
     "lint:fix": "eslint src --fix && pnpm format",
     "lint:strict": "eslint --max-warnings=0 src",
     "typecheck": "tsc --noEmit",

--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -63,7 +63,7 @@ describe('Header Component', () => {
       render(<Header />);
       const exhibitionLink = screen.getByRole('link', { name: /exhibition/i });
       expect(exhibitionLink).toBeInTheDocument();
-      expect(exhibitionLink).toHaveAttribute('href', '/exhibition/');
+      expect(exhibitionLink).toHaveAttribute('href', '/exhibition');
     });
 
     it('should have all navigation links', () => {

--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -59,11 +59,18 @@ describe('Header Component', () => {
       expect(articlesLink).toHaveAttribute('href', '/articles');
     });
 
+    it('should render Exhibition link', () => {
+      render(<Header />);
+      const exhibitionLink = screen.getByRole('link', { name: /exhibition/i });
+      expect(exhibitionLink).toBeInTheDocument();
+      expect(exhibitionLink).toHaveAttribute('href', '/exhibition/');
+    });
+
     it('should have all navigation links', () => {
       render(<Header />);
       const navLinks = screen.getAllByRole('link');
-      // Should have at least 4 links (logo + 3 nav items)
-      expect(navLinks.length).toBeGreaterThanOrEqual(4);
+      // Should have at least 5 links (logo + 4 nav items)
+      expect(navLinks.length).toBeGreaterThanOrEqual(5);
     });
   });
 
@@ -111,9 +118,11 @@ describe('Header Component', () => {
       const aboutLink = screen.getByRole('link', { name: /about/i });
       const teamLink = screen.getByRole('link', { name: /team/i });
       const articlesLink = screen.getByRole('link', { name: /articles/i });
+      const exhibitionLink = screen.getByRole('link', { name: /exhibition/i });
       expect(aboutLink).toBeInTheDocument();
       expect(teamLink).toBeInTheDocument();
       expect(articlesLink).toBeInTheDocument();
+      expect(exhibitionLink).toBeInTheDocument();
     });
   });
 
@@ -127,7 +136,7 @@ describe('Header Component', () => {
     it('should render list items for each nav link', () => {
       render(<Header />);
       const listItems = screen.getAllByRole('listitem');
-      expect(listItems.length).toBe(3); // About, Team, Articles
+      expect(listItems.length).toBe(4); // About, Team, Articles, Exhibition
     });
 
     it('should use NavLink components', () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -35,7 +35,7 @@ export default function Header() {
 
   return (
     <header className='pointer-events-none fixed z-30 flex w-full justify-center'>
-      <div className='pointer-events-auto relative mt-8 flex items-center justify-between gap-3 overflow-hidden rounded-full border-[1px] border-solid border-black bg-white/85 px-2 py-2 pl-4 shadow-sm backdrop-blur-md dark:border-white/20 dark:bg-neutral-950/85 sm:gap-32'>
+      <div className='pointer-events-auto relative mt-8 flex items-center justify-between gap-3 rounded-full border-[1px] border-solid border-black bg-white/85 px-2 py-2 pl-4 shadow-sm backdrop-blur-md dark:border-white/20 dark:bg-neutral-950/85 sm:gap-32'>
         <Link
           href='/'
           aria-label='Go to homepage'

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
- 'use client';
+'use client';
 
-import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
+import Link from 'next/link';
 import * as React from 'react';
 
 import { Logo } from '@/components/ui/icons/Logo';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,7 +12,7 @@ const navLinks = [
   { href: '/about', text: 'About' },
   { href: '/team', text: 'Team' },
   { href: '/articles', text: 'Articles' },
-  { href: '/exhibition/', text: 'Exhibition' },
+  { href: '/exhibition', text: 'Exhibition' },
 ];
 
 function Navigation() {
@@ -32,6 +32,32 @@ function Navigation() {
 export default function Header() {
   const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
   const mobileNavId = React.useId();
+  const mobileNavRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!mobileNavOpen) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setMobileNavOpen(false);
+    }
+
+    function onPointerDown(e: MouseEvent | TouchEvent) {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (mobileNavRef.current?.contains(target)) return;
+      setMobileNavOpen(false);
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('touchstart', onPointerDown, { passive: true });
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('touchstart', onPointerDown);
+    };
+  }, [mobileNavOpen]);
 
   return (
     <header className='pointer-events-none fixed z-30 flex w-full justify-center'>
@@ -69,6 +95,7 @@ export default function Header() {
 
         <div
           id={mobileNavId}
+          ref={mobileNavRef}
           className='absolute left-0 top-full mt-2 w-full px-2 sm:hidden'
           hidden={!mobileNavOpen}
         >
@@ -79,7 +106,12 @@ export default function Header() {
             <ul className='flex flex-col gap-1'>
               {navLinks.map((link) => (
                 <li key={link.href}>
-                  <NavLink href={link.href}>{link.text}</NavLink>
+                  <NavLink
+                    href={link.href}
+                    onClick={() => setMobileNavOpen(false)}
+                  >
+                    {link.text}
+                  </NavLink>
                 </li>
               ))}
             </ul>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,8 @@
+ 'use client';
+
 import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+import * as React from 'react';
 
 import { Logo } from '@/components/ui/icons/Logo';
 import NavLink from '@/components/ui/NavLink';
@@ -8,6 +12,7 @@ const navLinks = [
   { href: '/about', text: 'About' },
   { href: '/team', text: 'Team' },
   { href: '/articles', text: 'Articles' },
+  { href: '/exhibition/', text: 'Exhibition' },
 ];
 
 function Navigation() {
@@ -25,6 +30,9 @@ function Navigation() {
 }
 
 export default function Header() {
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
+  const mobileNavId = React.useId();
+
   return (
     <header className='pointer-events-none fixed z-30 flex w-full justify-center'>
       <div className='pointer-events-auto relative mt-8 flex items-center justify-between gap-3 overflow-hidden rounded-full border-[1px] border-solid border-black bg-white/85 px-2 py-2 pl-4 shadow-sm backdrop-blur-md dark:border-white/20 dark:bg-neutral-950/85 sm:gap-32'>
@@ -35,9 +43,47 @@ export default function Header() {
         >
           <Logo className='w-24 sm:w-48' variant='textOnly' />
         </Link>
+
         <div className='flex items-center gap-1'>
-          <Navigation />
+          <div className='hidden sm:block'>
+            <Navigation />
+          </div>
+
+          <button
+            type='button'
+            className='inline-flex h-8 w-8 items-center justify-center rounded-2xl px-2 py-1 text-sm transition-colors hover:bg-neutral-200/75 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg dark:hover:bg-neutral-700/75 dark:hover:text-white sm:hidden'
+            aria-label={mobileNavOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={mobileNavOpen}
+            aria-controls={mobileNavId}
+            onClick={() => setMobileNavOpen((v) => !v)}
+          >
+            {mobileNavOpen ? (
+              <X className='h-4 w-4' aria-hidden='true' />
+            ) : (
+              <Menu className='h-4 w-4' aria-hidden='true' />
+            )}
+          </button>
+
           <ThemeToggle />
+        </div>
+
+        <div
+          id={mobileNavId}
+          className='absolute left-0 top-full mt-2 w-full px-2 sm:hidden'
+          hidden={!mobileNavOpen}
+        >
+          <nav
+            aria-label='Mobile navigation'
+            className='rounded-3xl border border-black bg-white/95 p-2 shadow-sm backdrop-blur-md dark:border-white/20 dark:bg-neutral-950/95'
+          >
+            <ul className='flex flex-col gap-1'>
+              {navLinks.map((link) => (
+                <li key={link.href}>
+                  <NavLink href={link.href}>{link.text}</NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
         </div>
       </div>
     </header>

--- a/src/components/ui/NavLink.tsx
+++ b/src/components/ui/NavLink.tsx
@@ -9,9 +9,11 @@ import clsxm from '@/lib/clsxm';
 const NavLink = ({
   href,
   children,
+  onClick,
 }: {
   href: string;
   children: React.ReactNode;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 }) => {
   const pathname = usePathname();
   const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href);
@@ -19,6 +21,7 @@ const NavLink = ({
   return (
     <Link
       href={href}
+      onClick={onClick}
       className={clsxm(
         'rounded-2xl px-2 py-1 text-sm hover:bg-neutral-200/75 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg dark:hover:bg-neutral-700/75 dark:hover:text-white sm:text-lg',
         isActive && 'bg-black text-white dark:bg-white dark:text-black',

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/public/:path*",
+      "destination": "https://sentiment-exhibition.vercel.app/public/:path*"
+    },
+    {
       "source": "/exhibition",
       "destination": "https://sentiment-exhibition.vercel.app/"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,18 @@
 {
   "rewrites": [
     {
+      "source": "/api/events",
+      "destination": "https://sentiment-exhibition.vercel.app/api/events/"
+    },
+    {
+      "source": "/api/events/",
+      "destination": "https://sentiment-exhibition.vercel.app/api/events/"
+    },
+    {
+      "source": "/api/events/:path*",
+      "destination": "https://sentiment-exhibition.vercel.app/api/events/:path*"
+    },
+    {
       "source": "/public/:path*",
       "destination": "https://sentiment-exhibition.vercel.app/public/:path*"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,13 @@
 {
   "rewrites": [
-    { "source": "/exhibition", "destination": "https://sentiment-exhibition.vercel.app/" },
-    { "source": "/exhibition/", "destination": "https://sentiment-exhibition.vercel.app/" },
+    {
+      "source": "/exhibition",
+      "destination": "https://sentiment-exhibition.vercel.app/"
+    },
+    {
+      "source": "/exhibition/",
+      "destination": "https://sentiment-exhibition.vercel.app/"
+    },
     {
       "source": "/exhibition/:path*",
       "destination": "https://sentiment-exhibition.vercel.app/:path*"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "rewrites": [
+    { "source": "/exhibition", "destination": "https://sentiment-exhibition.vercel.app/" },
+    { "source": "/exhibition/", "destination": "https://sentiment-exhibition.vercel.app/" },
+    {
+      "source": "/exhibition/:path*",
+      "destination": "https://sentiment-exhibition.vercel.app/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Vercel rewrites to serve the exhibition app under `/exhibition/` and updates the header navigation to include an “Exhibition” link with a mobile-friendly hamburger menu.

- Adds `vercel.json` rewrites for `/exhibition` -> `https://sentiment-exhibition.vercel.app/`
- Adds “Exhibition” to nav
- Mobile navigation: toggle button + dropdown, a11y attributes
- Fixes repo lint script (Next.js CLI no longer provides `next lint` here), so `pnpm lint` works again
- Adds rewrite for `/public/*` to the exhibition app to avoid 404s when the embedded app requests assets with `/public/...`
- Adds rewrites for `/api/events*` to proxy the exhibition events endpoint (handles missing trailing slash)
- Fixes mobile dropdown being clipped by removing `overflow-hidden` on the header pill container
- Closes mobile menu on link click, Escape, and outside-click

Verification:
- `pnpm lint` ✅
- `pnpm test` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->