### PR TITLE
ci: pin pnpm version via packageManager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: 🤌 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -95,5 +95,5 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.1.0"
+  "packageManager": "pnpm@10.33.4"
 }

--- a/package.json
+++ b/package.json
@@ -95,11 +95,5 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.1.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp",
-      "unrs-resolver"
-    ]
-  }
+  "packageManager": "pnpm@11.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -95,12 +95,5 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@10.33.4",
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.14",
-      "@types/react-dom": "npm:types-react-dom@19.0.0",
-      "typescript-eslint": "8.59.2"
-    }
-  }
+  "packageManager": "pnpm@11.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -95,5 +95,11 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.1.0"
+  "packageManager": "pnpm@11.1.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "unrs-resolver"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3"
   },
+  "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "overrides": {
       "@types/react": "19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/react': 19.2.14
-  '@types/react-dom': npm:types-react-dom@19.0.0
-  typescript-eslint: 8.59.2
-
 importers:
 
   .:
@@ -1262,7 +1257,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': 19.2.14
+      '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+packages: []
 allowBuilds:
   sharp: true
   unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-packages: []
-allowBuilds:
-  sharp: true
-  unrs-resolver: true


### PR DESCRIPTION
Renovate regenerated lockfiles with pnpm 11 (its default), which strips
the unused-looking pnpm.overrides block. CI runs pnpm 10 with
--frozen-lockfile and rejects the mismatch
(ERR_PNPM_LOCKFILE_CONFIG_MISMATCH), failing every dependency PR.

Pinning pnpm@10.33.4 via packageManager makes Renovate, Corepack, and
the pnpm/action-setup step all use the same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized package manager: project now declares pnpm@11.1.0 and removed localized pnpm overrides to streamline dependency handling.
  * CI update: removed explicit pnpm version pin so continuous integration will use the runner’s pnpm by default.
  * Workspace update: enabled additional build support for select native packages to improve build compatibility across the monorepo.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dmnktoe/sentiment/pull/315)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->