### PR TITLE
fix(build): drop settings-only pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact = true
 strict-peer-dependencies=false
+minimum-release-age=1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,0 @@
-minimumReleaseAge: 1440


### PR DESCRIPTION
## Problem

Deployments fail since #387 with:

```
#11 [stage-0 7/11] RUN pnpm install --frozen-lockfile
#11 0.878 ERROR packages field missing or empty
```

#387 added a `pnpm-workspace.yaml` containing only a setting:

```yaml
minimumReleaseAge: 1440
```

As soon as that file exists, pnpm treats the repo as a workspace root. Only pnpm >= 10.16 accepts a settings-only manifest without a `packages` field; the pnpm shipped in the Nixpacks build image (`ghcr.io/railwayapp/nixpacks:ubuntu-1745885067`) is older and aborts.

It went unnoticed because local dev and CI run pnpm 10 (`ci.yml` pins `version: 10`) — only the deploy image uses an older version.

## Change

- Delete `pnpm-workspace.yaml` — this is a single-package repo, not a workspace.
- Move the setting to `.npmrc` as `minimum-release-age=1440`. Newer pnpm picks it up, older versions silently ignore unknown keys instead of failing.

The Renovate-side delay is unaffected — it stays configured via `"minimumReleaseAge": "3 days"` in `.github/renovate.json`.

## Verification

`pnpm install --frozen-lockfile` runs clean with no lockfile changes (pnpm 10.33). `pnpm config get minimum-release-age` returns `1440`, confirming the `.npmrc` key is honoured.

## Notes

- Adding a `packageManager: "pnpm@10.x"` field to `package.json` would additionally pin the pnpm version inside the deploy image (Nixpacks then enables Corepack). That is more robust against this class of version drift, but it changes build behaviour, so it is left out of this fix.
- Alternatively the settings-only file could be kept if the Coolify deploy is configured to use a newer pnpm than the image default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGa5VhTpdhqAvcyQbt6aPq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to enforce a 24-hour release age for newly published packages.
  * Consolidated this setting into the project’s package manager configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->